### PR TITLE
IKE: More Cluster Types, Aux Heat Sensor Bit, Fuel Level Byte

### DIFF
--- a/ike/13.md
+++ b/ike/13.md
@@ -30,22 +30,29 @@ The examples I've seen appear to be backwards compatible.
 
 ## Parameters
 
-**The longer variant of the command is not covered!**
+Fixed length. 3 or 7 byte bit field.
 
-Fixed length. 3 byte bit field.
+    # Byte 1
 
     HANDBRAKE       = 0b0000_0001 << 16
     OIL_PRESSURE    = 0b0000_0010 << 16
     BRAKE_PADS      = 0b0000_0100 << 16
     TRANSMISSION    = 0b0001_0000 << 16
-    
+
+    # Byte 2:   
+
     IGNITION        = 0b0000_0001 << 8
     DOOR            = 0b0000_0010 << 8
     GEAR            = 0b1111_0000 << 8
 
+    # Byte 3
+
     AUX_VENT        = 0b0000_1000
-    
-    # Aux. Heat direct?
+    AUX_HEAT        = 0b0000_0100
+
+    # Byte 7 (IKI only)
+
+    FUEL_LEVEL      = 0b1111_1111
     
     # IKI (E39-KMBI_E38.C12)
     # Fuel tank lid open warning?
@@ -82,7 +89,7 @@ In the case of the E39, there are two sensors. Front left brake pad sensor [B16]
 
     TRANSMISSION_OK     = 0
     TRANSMISSION_FAULT  = 1
-   
+
 ---
 
 ### Ignition `0b0000_0001 << 8`
@@ -117,6 +124,14 @@ Only at KL-15 and above. Presumably doesn't apply to manual transmissions, but m
 
 ---
 
+### Aux. Heating `0b0000_0100`
+
+Activation of aux. heating.
+
+    AUX_VENT_OFF    = 0
+    AUX_VENT_ON     = 1
+
+
 ### Aux. Ventilation `0b0000_1000`
 
 Activation of aux. ventilation.
@@ -131,7 +146,9 @@ Activation of aux. ventilation.
 > The check control receives information from the IKE for the following messages.
 >
 > - Transmission emergency program
-> - Release parking brake> - Check brake pad> - Stop! Engine oil pressure
+> - Release parking brake
+> - Check brake pad
+> - Stop! Engine oil pressure
 
 The driver's door warning is activated by the door status reported with `0x7a`.
 

--- a/ike/13.md
+++ b/ike/13.md
@@ -128,8 +128,8 @@ Only at KL-15 and above. Presumably doesn't apply to manual transmissions, but m
 
 Activation of aux. heating.
 
-    AUX_VENT_OFF    = 0
-    AUX_VENT_ON     = 1
+    AUX_HEAT_OFF    = 0
+    AUX_HEAT_ON     = 1
 
 
 ### Aux. Ventilation `0b0000_1000`

--- a/ike/15.md
+++ b/ike/15.md
@@ -123,19 +123,26 @@ There are also a number of flags for vehicle equipment, and configuration which 
     LANG_FR             = 0b000_0110
     LANG_EN_CA          = 0b000_0111
     LANG_GOLF           = 0b000_1000
+     
     
 `GOLF 0x08`: I'm not quite sure of meaning. It was the factory delivered language for Australian 2001 E39, and 2005 E53 and NCSDummy translation for "GOLF" is "persian gulf states"?
 
 ### Cluster Type `0b1111_0000 << 24`
 
-    CLUSTER_HIGH    = 0b0000_0000   # E38 standard, E39/E53 option
-    CLUSTER_LOW     = 0b0000_0011   # E39/E53 standard
+    CLUSTER_E38_E39_E53    = 0b0000_0000   # E38 standard, E39/E53 option
+    CLUSTER_E39_E53        = 0b0011_0000   # E39/E53 standard
+
+    CLUSTER_E52            = 0b0010_0000   # E52 Z8
     
-    CLUSTER_E46_A   = 0b0100_0000   # Variant A?
-    CLUSTER_E46_B   = 0b0110_0000   # Variant B?
-    CLUSTER_E46_C   = 0b1111_0000   # Variant C?
+    CLUSTER_R40            = 0b0101_0000   # MINI R40
+    CLUSTER_R50            = 0b1011_0000   # MINI R50
+    CLUSTER_R55            = 0b1100_0000   # MINI R55-R61
+
+    CLUSTER_E46_A          = 0b0100_0000   # Variant A?
+    CLUSTER_E46_B          = 0b0110_0000   # Variant B?
+    CLUSTER_E46_C          = 0b1111_0000   # Variant C?
     
-    CLUSTER_E85     = 0b1010_0000   # E85 Z4, E83 X3
+    CLUSTER_E83_E85        = 0b1010_0000   # E85 Z4, E83 X3
 
 This may affect the behaiour of radio, and telephone, neither of which is coded for a specific type of cluster, but will make use of high cluster (IKE/IKI) character display if available.
 

--- a/ike/15.md
+++ b/ike/15.md
@@ -134,7 +134,8 @@ There are also a number of flags for vehicle equipment, and configuration which 
 
     CLUSTER_E52            = 0b0010_0000   # E52 Z8
     
-    CLUSTER_R40            = 0b0101_0000   # MINI R40
+    CLUSTER_R40            = 0b0101_0000   # Rover 75 (R40)
+    
     CLUSTER_R50            = 0b1011_0000   # MINI R50
     CLUSTER_R55            = 0b1100_0000   # MINI R55-R61
 


### PR DESCRIPTION
I've added some cluster types to 0x15, the aux heat bit and fuel level byte (for IKI) to 0x13.