### PR TITLE
IKE Odometer, Fuel Level & Aux Heat Sensor State, SMS Icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ MINI and Range Rover (early L322) implementations are not discussed.
 >
 > The M-Bus was introduced on the E38 climate control system (IHKA). The M-Bus was also installed on subsequent models equipped with IHKA and IHKR.
 
-#### **Peripheral Bus** (P-Bus)> The P-Bus is a single wire serial communications bus that is used exclusively on vehicle that are equipped with ZKE III. These vehicles are the E38, E39 and E53.
+#### **Peripheral Bus** (P-Bus)
+> The P-Bus is a single wire serial communications bus that is used exclusively on vehicle that are equipped with ZKE III. These vehicles are the E38, E39 and E53.
 >
 > The P-Bus provides the Central Body Electronics system with a low speed bus for use by the General Module (GM) to control various functions. 
 
@@ -196,8 +197,8 @@ Command|Description
 `0x13`|[Sensors](ike/13.md)
 `0x14`|[Language & Region Request](ike/14.md)
 `0x15`|[Language & Region](ike/15.md)
-`0x16`|Mileage Request
-`0x17`|Mileage
+`0x16`|[Odometer Request](ike/16.md)
+`0x17`|[Odometer](ike/17.md)
 `0x18`|Speed
 `0x19`|[Temperature](ike/19.md)
 `0x1a`|[Check Control Message](lcm/1a.md)

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ Command|Description
 1. `0x11` [Ignition](ike/11.md)
 1. `0x12` [Sensors Request](ike/12.md)
 1. `0x13` [Sensors](ike/13.md)
+1. `0x16` [Odometer Request](ike/16.md)
+1. `0x17` [Odometer](ike/17.md)
 1. `0x19` [Temperature](ike/19.md)
 1. `0x1d` [Temperature Request](ike/1d.md)
 

--- a/ike/13.md
+++ b/ike/13.md
@@ -33,19 +33,28 @@ The examples I've seen appear to be backwards compatible.
 **The longer variant of the command is not covered!**
 
 Fixed length. 3 byte bit field.
+    
+    # Byte 1
 
     HANDBRAKE       = 0b0000_0001 << 16
     OIL_PRESSURE    = 0b0000_0010 << 16
     BRAKE_PADS      = 0b0000_0100 << 16
     TRANSMISSION    = 0b0001_0000 << 16
-    
+
+    # Byte 2
+
     IGNITION        = 0b0000_0001 << 8
     DOOR            = 0b0000_0010 << 8
     GEAR            = 0b1111_0000 << 8
+    
+    # Byte 3
 
     AUX_VENT        = 0b0000_1000
+    AUX_HEAT        = 0b0000_0100
     
-    # Aux. Heat direct?
+    # Byte 7 (IKI only)
+
+    FUEL_LEVEL      = 0b1111_1111
     
     # IKI (E39-KMBI_E38.C12)
     # Fuel tank lid open warning?
@@ -124,6 +133,13 @@ Activation of aux. ventilation.
     AUX_VENT_OFF    = 0
     AUX_VENT_ON     = 1
 
+### Aux. Heating `0b0000_0100`
+
+Activation of aux. heating.
+
+    AUX_HEAT_OFF    = 0
+    AUX_HEAT_ON     = 1
+
 ## Use Cases
 
 ### Check Control
@@ -131,7 +147,9 @@ Activation of aux. ventilation.
 > The check control receives information from the IKE for the following messages.
 >
 > - Transmission emergency program
-> - Release parking brake> - Check brake pad> - Stop! Engine oil pressure
+> - Release parking brake
+> - Check brake pad
+> - Stop! Engine oil pressure
 
 The driver's door warning is activated by the door status reported with `0x7a`.
 

--- a/ike/16.md
+++ b/ike/16.md
@@ -1,0 +1,19 @@
+# `0x16` Odometer Request
+
+### Related Commands
+
+- `0x17` [Odometer](17.md)
+
+### Examples
+
+    44 03 80 16 D1  # EWS
+    
+## Parameters
+
+None. Fixed length.
+
+## Use Cases
+
+### EWS
+
+> Requests the odometer for increasing mileage in EWS and inserted key

--- a/ike/17.md
+++ b/ike/17.md
@@ -1,0 +1,49 @@
+# `0x17` Odometer
+
+Cluster `0x80` → Broadcast `0xbf`
+
+The cluster will broadcast the odometer if requested.
+
+### Related Commands
+
+- `0x16` [Odometer Request](16.md)
+
+### Example Frame
+
+    80 0A BF 17 FA 34 0C 00 1F 32 CC 01
+
+## Parameters
+
+Fixed length. 3 data bytes.
+
+ Parameter | Index | Length | Type    | Note 
+:----------|:------|:-------|:--------|:-----
+ Mileage   | `0-2` | `3`    | Integer | km   
+
+### Mileage
+
+The mileage consists of 3 bytes. It can be calculated into a readable integer using the following formular:
+
+    mileage = (byte3 * 655536) + (byte2 * 256) + byte1  
+
+    mileage = (0x0C * 65536) + (0x34 * 256) + 0xFA
+
+    mileage = (12 * 65536) + (52 * 256) + 250
+
+    mileage = 799994
+
+## Example
+
+    # Example Odometer Frame
+    80 0A BF 17 FA 34 0C 00 1F 32 CC 01
+
+ Property  | Mileage    
+-----------|------------
+ **Data**  | `FA 34 0C` 
+ **Value** | 799994 km        
+
+## Use Cases
+
+### EWS
+
+> Increases the mileage in EWS and inserted key

--- a/telephone/2d.md
+++ b/telephone/2d.md
@@ -1,0 +1,32 @@
+# `0x2d` Direct Dial
+
+GT `0x3b` → Telephone `0xc8`
+
+
+Note: This command only seems to work with BMW Assist compatible phones.
+- Motorola HW 06 and SW 05 (or higher)
+- BIT HW 02 and SW 04 (or higher)
+
+### Example Frames
+
+    3B 13 C8 2D 00 11 2B 34 39 38 39 31 32 35 30 31 36 30 30 30 CA    # +4989125016000  (BMW Germany)
+    3B 11 C8 2D 00 11 2B 31 38 30 30 38 33 31 31 31 31 37 C0          # +18008311117    (BMW USA)
+
+## Parameters
+
+Length will vary with *String*.
+
+Property| Index |Length|Type
+:-------|:------|:-----|:---
+Phone Number| `2`   |`-1`|String
+
+
+## Use Cases
+
+### Navigation POI List
+
+> The user can directly dial a number of a service center, fuel station or any other POI with a phone number. 
+
+### BMW Assist
+
+> BMW Assist probably uses this command too, but this is unconfirmed.

--- a/telephone/a6.md
+++ b/telephone/a6.md
@@ -2,7 +2,7 @@
 
 ![icon](a6/icon.JPG)
 
-Presumably a component of messaging function originally introducted with BMW Assist.
+This icon is displayed when an SMS has been received and not yet read.
 
     # Show icon
     C8 05 E7 A6 00 01 8D


### PR DESCRIPTION
I added the odometer request and answer command to the IKE.
There are an additional 4 bytes that I have no idea what they are for.

Also I can confirm that the SMS icon was used in production, because SMS is working/worked in my car.
The SMS menu is also present on my 16:9 video module, it's not MK4 exclusive.

Interestingly this only worked with my old Phase V interface which was from arround 1998.

With the new Motorola interface, which is from arround 2003, it doesn't work anymore.
It just does nothing when I click the SMS item. Maybe because it is for usage with an mobile Motorola phone, idk.
I don't think it can be coded with NCS.

I could swap the old one back in the car. Only replaced it, so that I can check out the BMW Assist menu which is useless anyway. :D
